### PR TITLE
Use Ember 1.12 computed + Ember.meta

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
   "name": "ember-computed-indirect",
   "dependencies": {
     "jquery": "^1.11.1",
-    "ember": ">=1.10.0",
+    "ember": ">=1.12.0",
     "ember-resolver": "~0.1.12",
     "loader.js": "ember-cli/loader.js#3.2.0",
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",


### PR DESCRIPTION
I was playing around with this concept myself trying to see if there was a better way than `addObserver` and ended up with something extremely similar to what you had in the end.

Here are the ways I ended up changing it:
- Updated this for the Ember 1.12 computed syntax
- I used a property on `Ember.meta` to store the last key / observer.
- I switched to using `get`, `set`, `addObserver`, and `removeObserver` from `import Ember` instead of relying on `this.get` and `this.set` (I have run into problems where "get" had been redefined on an AJAX proxy service in the past).
- Used `Ember.computed` instead of assuming that people will have the `Function.protoype` extensions enabled.

I was messing around with it in this fiddle: http://emberjs.jsbin.com/renavapixe/1/edit?js,output

Happy to break this up into a couple different commits if you want me to
