### PR TITLE
Added the ability to `import computedIndirect from 'ember-computed-indirect'` directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ is that you can have one property store a reference to the property you would re
 getting updates when either the referenced property or the reference changes. Example:
  
 ```js
-import computedIndirect from 'ember-computed-indirect/utils/indirect';
+import computedIndirect from 'ember-computed-indirect';
 
 var object = Ember.Object.extend({
   source1: 'value1',

--- a/addon/index.js
+++ b/addon/index.js
@@ -1,0 +1,3 @@
+import computedIndirect from './utils/indirect';
+
+export default computedIndirect;

--- a/tests/unit/utils/indirect-test.js
+++ b/tests/unit/utils/indirect-test.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 import { module, test } from 'qunit';
-import computedIndirect from 'ember-computed-indirect/utils/indirect';
+import computedIndirect from 'ember-computed-indirect';
 
 var IndirectObject = Ember.Object.extend({
   source1: 'value1',


### PR DESCRIPTION
Bugged me a little so I thought I'd make it slightly easier to import.

Old syntax still works fine.
