### PR TITLE
Fix ember-cli preprocessor deprecation

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,12 +21,14 @@
     "broccoli-asset-rev": "^2.0.0",
     "ember-cli": "0.2.0",
     "ember-cli-app-version": "0.3.2",
-    "ember-cli-babel": "^4.0.0",
     "ember-cli-dependency-checker": "0.0.8",
     "ember-cli-htmlbars": "0.7.4",
     "ember-cli-qunit": "0.3.9",
     "ember-cli-uglify": "1.0.1",
     "ember-export-application-global": "^1.0.2"
+  },
+  "dependencies": {
+    "ember-cli-babel": "^4.0.0"
   },
   "keywords": [
     "ember-addon"


### PR DESCRIPTION
Not sure when it was added, but in `ember-cli` version 2.12 I'm seeing a deprecation during build:
```
🚀 tricorder$ ember build
DEPRECATION: Addon files were detected in `/Users/asikes/dev/tricorder/node_modules/ember-computed-indirect/addon`, but no JavaScript preprocessors were found for `ember-computed-indirect`. Please make sure to add a preprocessor (most likely `ember-cli-babel`) to in `dependencies` (NOT `devDependencies`) in `ember-computed-indirect`'s `package.json`.
cleaning up...
Built project successfully. Stored in "dist/".
```
Promoting to a full dependency fixes this deprecation:
```
🚀 tricorder$ ember build
cleaning up...
Built project successfully. Stored in "dist/".
```