### PR TITLE
Update ember-cli-babel

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "ember-export-application-global": "^1.0.2"
   },
   "dependencies": {
-    "ember-cli-babel": "^4.0.0"
+    "ember-cli-babel": "^6.0.0"
   },
   "keywords": [
     "ember-addon"


### PR DESCRIPTION
Is there any reason `ember-cli-babel` is pinned at such an old version? It currently pulls in v4 of ember-cli-babel, including all of the extra packages and baggage. This increases the size of our modules folder a *lot*!